### PR TITLE
Add two approaches for mapping big-tables

### DIFF
--- a/slick-standards/build.sbt
+++ b/slick-standards/build.sbt
@@ -2,6 +2,10 @@ name := "slick-standards"
 version := "0.1"
 scalaVersion := "2.12.7"
 
+// BIG CASE-CLASS MAPPING
+libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.3"
+libraryDependencies += "io.underscore" %% "slickless" % "0.3.3"
+
 // DATABASE
 libraryDependencies += "org.postgresql" % "postgresql" % "42.2.5"
 libraryDependencies += "com.typesafe.slick" %% "slick" % "3.2.3"

--- a/slick-standards/src/test/scala/ir/snapptrip/standards/slick/SlickBigTableShapelessMapping.scala
+++ b/slick-standards/src/test/scala/ir/snapptrip/standards/slick/SlickBigTableShapelessMapping.scala
@@ -1,0 +1,90 @@
+package ir.snapptrip.standards.slick
+
+import ir.snapptrip.standards.{DatabaseConnector, DatabaseTests}
+import org.scalatest.FunSuite
+import ir.snapptrip.standards.ExtendedPostgresProfile
+import shapeless._
+import slickless._
+
+class SlickBigTableShapelessMapping extends FunSuite with DatabaseConnector with DatabaseTests {
+
+  import api._
+
+  test("A simple table creation-insertion-query") {
+    val sampleObj = BigClass(
+      None,
+      "a",     "b",     "c",
+      "d",     "e",     "f",
+      "g",     "h",     "i",
+      "j",     "k",     "l",
+      "m",     "n",     "o",
+      "p",     "q",     "r",
+      "s",     "t",     "u",
+      "v",     "w",     "x",
+      "y",     "z"
+    )
+    autoRollback(
+      for {
+        _   <- BigClassTable.all.schema.create
+        _   <- BigClassTable.all += sampleObj
+        obj <- BigClassTable.all.result.head
+      } yield {
+        assert(obj.copy(id = None) == sampleObj)
+      }
+    )
+  }
+
+  // MODELS ----------------------------------------------------------------------------------------------------------
+
+  /**
+    * case classes with more than 22 fields are allowed
+    * but the number of arguments/elements in Function/Tuples are still limited to 22.
+    *
+    * This solution is integrated into slick already, wait for Slick-3.3 release:
+    * https://github.com/slick/slick/pull/1889
+    */
+  case class BigClass(
+    id: Option[Long] = None,
+    a: String,     b: String,     c: String,
+    d: String,     e: String,     f: String,
+    g: String,     h: String,     i: String,
+    j: String,     k: String,     l: String,
+    m: String,     n: String,     o: String,
+    p: String,     q: String,     r: String,
+    s: String,     t: String,     u: String,
+    v: String,     w: String,     x: String,
+    y: String,     z: String
+  )
+
+  // MODEL-TABLE MAPPING ---------------------------------------------------------------------------------------------
+
+  class BigClassTable(tag: Tag) extends Table[BigClass](tag, "BigClassTable") {
+    val id = column[Long]("id", O.PrimaryKey, O.AutoInc).?
+    val a = column[String]("a");    val b = column[String]("b");    val c = column[String]("c")
+    val d = column[String]("d");    val e = column[String]("e");    val f = column[String]("f")
+    val g = column[String]("g");    val h = column[String]("h");    val i = column[String]("i")
+    val j = column[String]("j");    val k = column[String]("k");    val l = column[String]("l")
+    val m = column[String]("m");    val n = column[String]("n");    val o = column[String]("o")
+    val p = column[String]("p");    val q = column[String]("q");    val r = column[String]("r")
+    val s = column[String]("s");    val t = column[String]("t");    val u = column[String]("u")
+    val v = column[String]("v");    val w = column[String]("w");    val x = column[String]("x")
+    val y = column[String]("y");    val z = column[String]("z")
+    override def * = (
+      id ::
+      a :: b :: c ::
+      d :: e :: f ::
+      g :: h :: i ::
+      j :: k :: l ::
+      m :: n :: o ::
+      p :: q :: r ::
+      s :: t :: u ::
+      v :: w :: x ::
+      y :: z :: HNil
+    ).mappedWith(Generic[BigClass])
+  }
+
+  object BigClassTable {
+    val all = TableQuery[BigClassTable]
+  }
+
+}

--- a/slick-standards/src/test/scala/ir/snapptrip/standards/slick/SlickBigTableSplitMapping.scala
+++ b/slick-standards/src/test/scala/ir/snapptrip/standards/slick/SlickBigTableSplitMapping.scala
@@ -1,0 +1,119 @@
+package ir.snapptrip.standards.slick
+
+import ir.snapptrip.standards.{DatabaseConnector, DatabaseTests}
+import org.scalatest.FunSuite
+import shapeless._
+import slickless._
+
+class SlickBigTableSplitMapping extends FunSuite with DatabaseConnector with DatabaseTests {
+
+  import api._
+
+  test("A simple table creation-insertion-query") {
+    val sampleObj = BigClass(
+      None,
+      "a",     "b",     "c",
+      "d",     "e",     "f",
+      "g",     "h",
+      BigClassPart1(
+        "i",    "j",     "k",
+        "l",    "m",     "n",
+        "o",    "p",     "q",
+      ),
+      BigClassPart2(
+        "r",    "s",    "t",
+        "u",    "v",    "w",
+        "x",    "y",    "z"
+      )
+    )
+    autoRollback(
+      for {
+        _   <- BigClassTable.all.schema.create
+        _   <- BigClassTable.all += sampleObj
+        obj <- BigClassTable.all.result.head
+      } yield {
+        assert(obj.copy(id = None) == sampleObj)
+      }
+    )
+  }
+
+  // MODELS ----------------------------------------------------------------------------------------------------------
+
+  case class BigClass(
+    id: Option[Long] = None,
+    a: String,     b: String,     c: String,
+    d: String,     e: String,     f: String,
+    g: String,     h: String,
+    bigClassPart1: BigClassPart1,
+    bigClassPart2: BigClassPart2,
+  )
+
+  case class BigClassPart1(
+    i: String,    j: String,     k: String,
+    l: String,    m: String,     n: String,
+    o: String,    p: String,     q: String,
+  )
+
+  case class BigClassPart2(
+    r: String,    s: String,    t: String,
+    u: String,    v: String,    w: String,
+    x: String,    y: String,    z: String
+  )
+
+  // MODEL-TABLE MAPPING ---------------------------------------------------------------------------------------------
+
+  class BigClassTable(tag: Tag) extends Table[BigClass](tag, "BigClassTable") {
+    val id = column[Long]("id", O.PrimaryKey, O.AutoInc).?
+    val a = column[String]("a");    val b = column[String]("b");    val c = column[String]("c")
+    val d = column[String]("d");    val e = column[String]("e");    val f = column[String]("f")
+    val g = column[String]("g");    val h = column[String]("h");    val i = column[String]("i")
+    val j = column[String]("j");    val k = column[String]("k");    val l = column[String]("l")
+    val m = column[String]("m");    val n = column[String]("n");    val o = column[String]("o")
+    val p = column[String]("p");    val q = column[String]("q");    val r = column[String]("r")
+    val s = column[String]("s");    val t = column[String]("t");    val u = column[String]("u")
+    val v = column[String]("v");    val w = column[String]("w");    val x = column[String]("x")
+    val y = column[String]("y");    val z = column[String]("z")
+    override def * = (
+      id,
+      a, b, c,
+      d, e, f,
+      g, h,
+      (
+        i, j, k,
+        l, m, n,
+        o, p, q
+      ),
+      (
+        r, s, t,
+        u, v, w,
+        x, y, z
+      ),
+    ).shaped <> (
+      {
+        case (id, a, b, c, d, e, f, g, h, bigClassPart1Tuple, bigClassPart2Tuple) =>
+          BigClass(
+            id,
+            a, b, c, d, e, f, g, h,
+            BigClassPart1.tupled(bigClassPart1Tuple),
+            BigClassPart2.tupled(bigClassPart2Tuple),
+          )
+      },
+      {
+        bigClass: BigClass =>
+          Some((
+            bigClass.id,
+            bigClass.a, bigClass.b, bigClass.c,
+            bigClass.d, bigClass.e, bigClass.f,
+            bigClass.g, bigClass.h,
+            BigClassPart1.unapply(bigClass.bigClassPart1).get,
+            BigClassPart2.unapply(bigClass.bigClassPart2).get,
+          ))
+      }
+    )
+  }
+
+  object BigClassTable {
+    val all = TableQuery[BigClassTable]
+  }
+
+}


### PR DESCRIPTION
Scala has lifted case-class members limitations since Scala 2.12 but Function[..] and Tuple[..] still have limit on their argument number (no more than 22 arguments/members are supported).

Having a table with more than 22 columns is often already a sign of poor database design, however if it is already there and needs to be mapped to scala case-classes there are two methods to do this:

1. Using shapeless HList.
2. Grouping fields into several cohesive case-classes